### PR TITLE
add diff language to prism config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,7 +162,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ['java'],
+        additionalLanguages: ['java', 'diff'],
       },
     }),
 };


### PR DESCRIPTION
docusaurus 3.0 doesn't include diff by default it seems